### PR TITLE
Make git and npm tags branch-aware

### DIFF
--- a/lib/annotation.ts
+++ b/lib/annotation.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2020 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const Matchers = [
+	{
+		name: "npm",
+		severity: "error",
+		report: "always",
+		pattern: [
+			// TypeScript < 3.9 compile output
+			{
+				regexp:
+					"^(.*):([0-9]+):([0-9]+)\\s-\\s([\\S]+)\\s(.*):\\s(.*)\\.$",
+				groups: {
+					path: 1,
+					line: 2,
+					column: 3,
+					severity: 4,
+					title: 5,
+					message: 6,
+				},
+			},
+			// TypeScript 3.9 compile output
+			{
+				regexp:
+					"^(.*)\\(([0-9]+),([0-9]+)\\):\\s([\\S]+)\\s(.*):\\s(.*)\\.$",
+				groups: {
+					path: 1,
+					line: 2,
+					column: 3,
+					severity: 4,
+					title: 5,
+					message: 6,
+				},
+			},
+		],
+	},
+];
+
+export interface Annotation {
+	path: string;
+	line: number;
+	column: number;
+	severity: "failure" | "notice" | "warning";
+	title: string;
+	message: string;
+}
+
+export function extractAnnotations(lines: string): Annotation[] {
+	const logs = lines.split("\n");
+	const annotations = [];
+	for (const matcher of Matchers) {
+		for (const pattern of matcher.pattern) {
+			for (const l of logs) {
+				const match = new RegExp(pattern.regexp, "g").exec(l.trim());
+				if (match) {
+					annotations.push({
+						match: match[0],
+						path: match[pattern.groups.path],
+						line: match[pattern.groups.line],
+						column: match[pattern.groups.column],
+						severity: mapSeverity(
+							(
+								match[pattern.groups.severity] || "error"
+							).toLowerCase(),
+						),
+						message: match[pattern.groups.message],
+						title: match[pattern.groups.title],
+					});
+				}
+			}
+		}
+	}
+	return annotations;
+}
+
+function mapSeverity(severity: string): "notice" | "warning" | "failure" {
+	switch (severity.toLowerCase()) {
+		case "error":
+			return "failure";
+		case "warning":
+		case "warn":
+			return "warning";
+		case "info":
+		case "information":
+			return "notice";
+		default:
+			return "notice";
+	}
+}

--- a/lib/branch.ts
+++ b/lib/branch.ts
@@ -13,3 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/** Remove non-tag-worthy characters from git branch. */
+export function cleanGitBranch(branchName: string): string {
+	return branchName.replace(/\//g, "-").replace(/_/g, "-").replace(/@/g, "");
+}
+
+/** Return cleaned branch name prepended with "branch-". */
+export function gitBranchToNpmTag(branchName: string): string {
+	return `branch-${cleanGitBranch(branchName)}`;
+}

--- a/lib/configuration.ts
+++ b/lib/configuration.ts
@@ -17,7 +17,7 @@
 export interface Configuration {
 	version: string;
 	scripts: string[];
-	publish: boolean;
+	publish: string;
 	access: string;
 	tag: string[];
 	command: string;

--- a/lib/events/onPush.ts
+++ b/lib/events/onPush.ts
@@ -29,7 +29,6 @@ import {
 	Step,
 	subscription,
 } from "@atomist/skill";
-import { Octokit } from "@octokit/rest";
 import * as fs from "fs-extra";
 import * as os from "os";
 import * as pRetry from "p-retry";
@@ -325,9 +324,9 @@ const NpmVersionStep: NpmStep = {
 				apiUrl: repo.org.provider.apiUrl,
 			}),
 		);
-		const octokit = new Octokit({
-			auth: credential.token,
-			userAgent: "@atomist/npm-build-skill 0.1.0",
+		const octokit = github.api({
+			apiUrl: repo.org?.provider?.apiUrl,
+			credential,
 		});
 
 		let version: string;

--- a/lib/events/onPush.ts
+++ b/lib/events/onPush.ts
@@ -29,47 +29,15 @@ import {
 	Step,
 	subscription,
 } from "@atomist/skill";
+import { Octokit } from "@octokit/rest";
 import * as fs from "fs-extra";
 import * as os from "os";
-import * as path from "path";
-import { Configuration } from "../configuration";
 import * as pRetry from "p-retry";
-
-const Matchers = [
-	{
-		name: "npm",
-		severity: "error",
-		report: "always",
-		pattern: [
-			// TypeScript < 3.9 compile output
-			{
-				regexp:
-					"^(.*):([0-9]+):([0-9]+)\\s-\\s([\\S]+)\\s(.*):\\s(.*)\\.$",
-				groups: {
-					path: 1,
-					line: 2,
-					column: 3,
-					severity: 4,
-					title: 5,
-					message: 6,
-				},
-			},
-			// TypeScript 3.9 compile output
-			{
-				regexp:
-					"^(.*)\\(([0-9]+),([0-9]+)\\):\\s([\\S]+)\\s(.*):\\s(.*)\\.$",
-				groups: {
-					path: 1,
-					line: 2,
-					column: 3,
-					severity: 4,
-					title: 5,
-					message: 6,
-				},
-			},
-		],
-	},
-];
+import * as path from "path";
+import { extractAnnotations } from "../annotation";
+import { gitBranchToNpmTag } from "../branch";
+import { Configuration } from "../configuration";
+import { nextPrereleaseTag } from "../tag";
 
 interface NpmParameters {
 	project: project.Project;
@@ -335,81 +303,54 @@ ${captureLog.log.trim()}
 	},
 };
 
-export interface Annotation {
-	path: string;
-	line: number;
-	column: number;
-	severity: "failure" | "notice" | "warning";
-	title: string;
-	message: string;
-}
-
-function extractAnnotations(lines: string): Annotation[] {
-	const logs = lines.split("\n");
-	const annotations = [];
-	for (const matcher of Matchers) {
-		for (const pattern of matcher.pattern) {
-			for (const l of logs) {
-				const match = new RegExp(pattern.regexp, "g").exec(l.trim());
-				if (match) {
-					annotations.push({
-						match: match[0],
-						path: match[pattern.groups.path],
-						line: match[pattern.groups.line],
-						column: match[pattern.groups.column],
-						severity: mapSeverity(
-							(
-								match[pattern.groups.severity] || "error"
-							).toLowerCase(),
-						),
-						message: match[pattern.groups.message],
-						title: match[pattern.groups.title],
-					});
-				}
-			}
-		}
-	}
-	return annotations;
-}
-
-function mapSeverity(severity: string): "notice" | "warning" | "failure" {
-	switch (severity.toLowerCase()) {
-		case "error":
-			return "failure";
-		case "warning":
-		case "warn":
-			return "warning";
-		case "info":
-		case "information":
-			return "notice";
-		default:
-			return "notice";
-	}
-}
-
 const NpmVersionStep: NpmStep = {
 	name: "version",
-	runWhen: async ctx => ctx.configuration?.[0]?.parameters.publish,
+	runWhen: async ctx =>
+		ctx.configuration?.[0]?.parameters.publish &&
+		ctx.configuration?.[0]?.parameters.publish !== "no",
 	run: async (ctx, params) => {
 		const push = ctx.data.Push[0];
 		let pj = await fs.readJson(params.project.path("package.json"));
 
-		let pjVersion = pj.version;
-		if (!pjVersion || pjVersion.length === 0) {
-			pjVersion = "0.0.0";
-		}
+		const pjVersion =
+			pj.version ||
+			(await github.nextTag(params.project.id, "patch")) ||
+			"0.1.0";
+
+		const repo = push.repo;
+		const credential = await ctx.credential.resolve(
+			secret.gitHubAppToken({
+				owner: repo.owner,
+				repo: repo.name,
+				apiUrl: repo.org.provider.apiUrl,
+			}),
+		);
+		const octokit = new Octokit({
+			auth: credential.token,
+			userAgent: "@atomist/npm-build-skill 0.1.0",
+		});
 
 		let version: string;
 		if (!pj.scripts?.version) {
 			version = await pRetry(
 				async () => {
-					const tag = await github.nextTag(
-						params.project.id,
-						"prerelease",
-						pjVersion,
+					const tags = await octokit.paginate(
+						"GET /repos/:owner/:repo/tags",
+						{
+							owner: repo.owner,
+							repo: repo.name,
+						},
+						response => response.data.map(t => t.name),
 					);
+					const tag = nextPrereleaseTag({
+						branch: push.branch,
+						defaultBranch: repo.defaultBranch,
+						nextReleaseVersion: pjVersion,
+						tags,
+					});
 					await params.project.exec("git", [
 						"tag",
+						"-a",
 						"-m",
 						`Version ${tag}`,
 						tag,
@@ -460,14 +401,13 @@ const NpmVersionStep: NpmStep = {
 	},
 };
 
-function gitBranchToNpmVersion(branchName: string): string {
-	// prettier-ignore
-	return branchName.replace(/\//g, "-").replace(/_/g, "-").replace(/@/g, "");
-}
-
 const NpmPublishStep: NpmStep = {
 	name: "npm publish",
-	runWhen: async ctx => ctx.configuration?.[0]?.parameters.publish,
+	runWhen: async ctx =>
+		ctx.configuration?.[0]?.parameters.publish &&
+		ctx.configuration?.[0]?.parameters.publish !== "no" &&
+		(ctx.configuration?.[0]?.parameters.publish === "all" ||
+			ctx.data.Push[0].branch === ctx.data.Push[0].repo.defaultBranch),
 	run: async (ctx, params) => {
 		const cfg = ctx.configuration?.[0]?.parameters;
 		const push = ctx.data.Push[0];
@@ -476,7 +416,7 @@ const NpmPublishStep: NpmStep = {
 		// add /.npm/ to the .npmignore file
 		const npmIgnore = params.project.path(".npmignore");
 		if (await fs.pathExists(npmIgnore)) {
-			const npmIgnoreContent = (await fs.readFile(npmIgnore)).toString();
+			const npmIgnoreContent = await fs.readFile(npmIgnore, "utf8");
 			await fs.writeFile(npmIgnore, `${npmIgnoreContent}\n/.npm/`);
 		} else {
 			await fs.writeFile(npmIgnore, "/.npm/");
@@ -560,7 +500,7 @@ Failed to publish ${pj.name}
 		}
 
 		const tags = cfg.tag || [];
-		if (ctx.data.Push[0].branch === ctx.data.Push[0].repo.defaultBranch) {
+		if (push.branch === push.repo.defaultBranch) {
 			tags.push("next");
 		}
 		for (const tag of tags) {
@@ -610,10 +550,6 @@ Successfully published ${pj.name} with version ${pj.version}
 		);
 	},
 };
-
-function gitBranchToNpmTag(branchName: string): string {
-	return `branch-${gitBranchToNpmVersion(branchName)}`;
-}
 
 export const handler: EventHandler<
 	subscription.types.OnPushSubscription,

--- a/lib/tag.ts
+++ b/lib/tag.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2020 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as semver from "semver";
+import { cleanGitBranch } from "./branch";
+
+export interface NextPrereleaseTagArgs {
+	/** Current branch */
+	branch: string;
+	/** Repository default branch */
+	defaultBranch: string;
+	/** Next release version */
+	nextReleaseVersion: string;
+	/** Current tags */
+	tags: string[];
+}
+
+/**
+ * Return the next prerelease semantic version tag.
+ */
+export function nextPrereleaseTag(args: NextPrereleaseTagArgs): string {
+	if (args.tags.includes(args.nextReleaseVersion)) {
+		throw new Error(
+			`Current tags already include next release version: ${args.nextReleaseVersion}`,
+		);
+	}
+	const semverTags = args.tags.filter(t => semver.valid(t));
+	const cleanBranch = cleanGitBranch(args.branch);
+	const nextVersion = args.nextReleaseVersion;
+	const prefixRegExp =
+		args.branch !== args.defaultBranch
+			? RegExp(`^${nextVersion}-${cleanBranch}\\.(?:0|[1-9]\\d*)$`)
+			: RegExp(`^${nextVersion}-(?:0|[1-9]\\d*)$`);
+	const matchingTags = semverTags.filter(t => prefixRegExp.test(t));
+	const sortedTags = matchingTags.sort((t1, t2) => semver.compare(t2, t1));
+	if (sortedTags.length < 1) {
+		return (
+			`${nextVersion}-` +
+			(args.branch !== args.defaultBranch ? `${cleanBranch}.` : "") +
+			"0"
+		);
+	}
+	return semver.inc(sortedTags[0], "prerelease");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,5 @@
 {
+  "name": "@atomist/npm-build-skill",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
@@ -3150,6 +3151,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.1.tgz",
       "integrity": "sha512-B42Sxuaz09MhC3DDeW5kubRcQ5by4iuVQ0cRRWM2lggLzAa/KVom0Aft/208NgMvNQQZ86s5rVcqDdn/SH0/mg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@atomist/skill": "^0.1.1-155",
-    "@octokit/rest": "^18.0.6",
     "fs-extra": "^9.0.1",
     "p-retry": "^4.2.0",
     "semver": "^7.3.2"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@atomist/skill": "^0.1.1-155",
-    "@types/fs-extra": "^9.0.1",
+    "@octokit/rest": "^18.0.6",
     "fs-extra": "^9.0.1",
     "p-retry": "^4.2.0",
     "semver": "^7.3.2"
@@ -22,8 +22,10 @@
     "@graphql-codegen/cli": "^1.17.8",
     "@graphql-codegen/typescript": "^1.17.9",
     "@graphql-codegen/typescript-operations": "^1.17.8",
+    "@types/fs-extra": "^9.0.1",
     "@types/mocha": "^7.0.2",
     "@types/power-assert": "^1.5.3",
+    "@types/semver": "^7.3.4",
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
     "eslint": "^7.9.0",

--- a/skill.ts
+++ b/skill.ts
@@ -59,10 +59,16 @@ export const Skill = skill<Configuration & { repos: any }>({
 			required: false,
 		},
 		publish: {
-			type: ParameterType.Boolean,
+			type: ParameterType.SingleChoice,
 			displayName: "Publish package",
 			description:
 				"Publish npm package to registry once all scripts successfully executed",
+			options: [
+				{ text: "No", value: "no" },
+				{ text: "Default branch only", value: "default" },
+				{ text: "All branches", value: "all" },
+			],
+			defaultValue: "no",
 			required: false,
 		},
 		access: {

--- a/test/branch.test.ts
+++ b/test/branch.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2020 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from "power-assert";
+import { cleanGitBranch, gitBranchToNpmTag } from "../lib/branch";
+
+describe("branch", () => {
+	describe("cleanGitBranch", () => {
+		it("does nothing to clean branch", () => {
+			["main", "nothing", "gh-pages", "clean-branch-name"].forEach(b => {
+				const c = cleanGitBranch(b);
+				assert(c === b);
+			});
+		});
+
+		it("cleans branch", () => {
+			[
+				{ b: "mainly@main", e: "mainlymain" },
+				{ b: "mainly_@_main", e: "mainly--main" },
+				{ b: "main/ly_@_main", e: "main-ly--main" },
+			].forEach(be => {
+				const c = cleanGitBranch(be.b);
+				assert(c === be.e);
+			});
+		});
+	});
+
+	describe("gitBranchToNpmTag", () => {
+		it("prepends to clean branch", () => {
+			["main", "nothing", "gh-pages", "clean-branch-name"].forEach(b => {
+				const c = gitBranchToNpmTag(b);
+				const e = `branch-${b}`;
+				assert(c === e);
+			});
+		});
+
+		it("cleans and prepends branch", () => {
+			[
+				{ b: "mainly@main", e: "branch-mainlymain" },
+				{ b: "mainly_@_main", e: "branch-mainly--main" },
+				{ b: "main/ly_@_main", e: "branch-main-ly--main" },
+			].forEach(be => {
+				const c = gitBranchToNpmTag(be.b);
+				assert(c === be.e);
+			});
+		});
+	});
+});

--- a/test/tag.test.ts
+++ b/test/tag.test.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2020 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from "power-assert";
+import { nextPrereleaseTag } from "../lib/tag";
+
+describe("tag", () => {
+	describe("nextPrereleaseTag", () => {
+		it("returns first prerelease when no tags", () => {
+			const n = nextPrereleaseTag({
+				branch: "main",
+				defaultBranch: "main",
+				nextReleaseVersion: "0.1.0",
+				tags: [],
+			});
+			const e = "0.1.0-0";
+			assert(n === e);
+		});
+
+		it("returns first prerelease when no matching tags", () => {
+			const n = nextPrereleaseTag({
+				branch: "main",
+				defaultBranch: "main",
+				nextReleaseVersion: "2.4.6",
+				tags: [
+					"0.1.0-0",
+					"0.1.0",
+					"1.0.0-0",
+					"1.0.0-feature.0",
+					"1.0.0",
+					"1.0.1-0",
+					"1.0.1",
+					"2.0.0-0",
+					"2.0.0",
+					"2.0.1-0",
+					"2.1.0-0",
+					"2.1.0",
+					"2.3.0-0",
+					"2.4.0",
+					"2.4.1-0",
+					"2.4.1",
+				],
+			});
+			const e = "2.4.6-0";
+			assert(n === e);
+		});
+
+		it("increments existing prerelease", () => {
+			const n = nextPrereleaseTag({
+				branch: "main",
+				defaultBranch: "main",
+				nextReleaseVersion: "2.1.1",
+				tags: [
+					"0.1.0-0",
+					"0.1.0",
+					"1.0.0-0",
+					"1.0.0-feature.0",
+					"1.0.0",
+					"1.0.1-0",
+					"1.0.1",
+					"2.0.0-0",
+					"2.0.0",
+					"2.0.1-0",
+					"2.1.0-0",
+					"2.1.0",
+					"2.1.1-0",
+					"2.1.1-1",
+					"2.1.1-feature.0",
+					"2.1.1-feature.1",
+					"2.1.1-feature.2",
+					"2.1.1-feature.3",
+					"2.1.1-2",
+				],
+			});
+			const e = "2.1.1-3";
+			assert(n === e);
+		});
+
+		it("returns first branch prerelease", () => {
+			const n = nextPrereleaseTag({
+				branch: "big/changes_in-store@s",
+				defaultBranch: "main",
+				nextReleaseVersion: "2.1.1",
+				tags: [
+					"0.1.0-0",
+					"0.1.0",
+					"1.0.0-0",
+					"1.0.0-feature.0",
+					"1.0.0",
+					"1.0.1-0",
+					"1.0.1",
+					"2.0.0-0",
+					"2.0.0",
+					"2.0.1-0",
+					"2.1.0-0",
+					"2.1.0",
+					"2.1.1-0",
+					"2.1.1-1",
+					"2.1.1-feature.0",
+					"2.1.1-feature.1",
+					"2.1.1-feature.2",
+					"2.1.1-feature.3",
+					"2.1.1-2",
+				],
+			});
+			const e = "2.1.1-big-changes-in-stores.0";
+			assert(n === e);
+		});
+
+		it("increments existing branch prerelease", () => {
+			const n = nextPrereleaseTag({
+				branch: "feature",
+				defaultBranch: "main",
+				nextReleaseVersion: "2.1.1",
+				tags: [
+					"0.1.0-0",
+					"0.1.0",
+					"1.0.0-0",
+					"1.0.0-feature.0",
+					"1.0.0",
+					"1.0.1-0",
+					"1.0.1",
+					"2.0.0-0",
+					"2.0.0",
+					"2.0.1-0",
+					"2.1.0-0",
+					"2.1.0",
+					"2.1.1-0",
+					"2.1.1-1",
+					"2.1.1-feature.0",
+					"2.1.1-feature.1",
+					"2.1.1-feature.2",
+					"2.1.1-feature.3",
+					"2.1.1-2",
+				],
+			});
+			const e = "2.1.1-feature.4";
+			assert(n === e);
+		});
+	});
+});


### PR DESCRIPTION
Make git and NPM semantic version tags branch aware. This means the
tags include the branch, if not the default, and increment
appropriately. Make publish parameter a choice, allowing publishing
only for default branch.  This also bases the version on the version
in the package.json, falling back to the next tag.

Move helper functions to separate files.  Add tests.